### PR TITLE
Fixes for QR code generation

### DIFF
--- a/src/main/java/hu/meza/tools/galib/GoogleAuthenticator.java
+++ b/src/main/java/hu/meza/tools/galib/GoogleAuthenticator.java
@@ -10,6 +10,9 @@ import java.nio.ByteBuffer;
 
 public class GoogleAuthenticator {
 
+	public static final String CHART_BASE_URL =
+			"https://chart.googleapis.com/chart?chs=200x200&chld=M%%7C0&cht=qr&chl=otpauth://totp/";
+
 	public static final long TIME_WINDOW = 30L;
 	public static final int CAPACITY = 8;
 	public static final int TOKEN_LENGTH = 6;
@@ -70,11 +73,13 @@ public class GoogleAuthenticator {
 		return false;
 	}
 
+	public String qRBarcodeURL(String user, String host, String secret, String issuer) {
+		String format = CHART_BASE_URL + "%s%%3A%s@%s%%3Fsecret%%3D%s%%26issuer%%3D%s";
+		return String.format(format, issuer, user, host, secret, issuer);
+	}
+
 	public String qRBarcodeURL(String user, String host, String secret) {
-		String format =
-			"https://www.google.com/chart?chs=200x200&chld=M%%7C0&cht=qr&chl=otpauth://totp/%s@%s" +
-			"%%3Fsecret" +
-			"%%3D%s";
+		String format = CHART_BASE_URL + "%s@%s%%3Fsecret%%3D%s";
 		return String.format(format, user, host, secret);
 	}
 
@@ -101,5 +106,3 @@ public class GoogleAuthenticator {
 		return val;
 	}
 }
-
-

--- a/src/test/java/hu/meza/tools/galib/GoogleAuthenticatorTest.java
+++ b/src/test/java/hu/meza/tools/galib/GoogleAuthenticatorTest.java
@@ -70,7 +70,8 @@ public class GoogleAuthenticatorTest {
 		final String secret = UUID.randomUUID().toString();
 
 		String expected = String
-			.format("https://www.google.com/chart?chs=200x200&chld=M%%7C0&cht=qr&chl=otpauth://totp/%s@%s" +
+			.format("https://chart.googleapis.com/chart?chs=200x200&chld=M%%7C0&cht" +
+					"=qr&chl=otpauth://totp/%s@%s" +
 					"%%3Fsecret" +
 					"%%3D%s", user, host, secret);
 
@@ -78,4 +79,22 @@ public class GoogleAuthenticatorTest {
 
 		Assert.assertEquals("did not generate the correct barcode url", expected, actual);
 	}
+
+	@Test
+	public void testQRBarcodeURLWithIssuer() {
+		final String user = UUID.randomUUID().toString();
+		final String host = UUID.randomUUID().toString();
+		final String secret = UUID.randomUUID().toString();
+		final String issuer = UUID.randomUUID().toString();
+
+		String expected = String
+		.format("https://chart.googleapis.com/chart?chs=200x200&chld=M%%7C0&cht=qr&chl=" +
+				"otpauth://totp/%s%%3A%s@%s%%3Fsecret" +
+				"%%3D%s%%26issuer%%3D%s", issuer, user, host, secret, issuer);
+
+		String actual = ga.qRBarcodeURL(user, host, secret, issuer);
+
+		Assert.assertEquals("did not generate the correct barcode url", expected, actual);
+	}
+
 }


### PR DESCRIPTION
I found that the current URL does not work anymore, so switch to https://chart.googleapis.com/chart

Also, added support for generating URL with issuer in it, see https://code.google.com/p/google-authenticator/wiki/KeyUriFormat